### PR TITLE
Add related songs component

### DIFF
--- a/src/lib/components/RelatedSongs.svelte
+++ b/src/lib/components/RelatedSongs.svelte
@@ -1,0 +1,22 @@
+<script>
+  import CardGrid from './CardGrid.svelte';
+  import SongCard from './SongCard.svelte';
+  import { liveQuery } from 'dexie';
+  import { db } from '$data/db';
+
+  export let categoryId;
+
+  $: relatedSongs = liveQuery(async () => {
+    return await db.songs.where('categori_id').equals(categoryId).toArray();
+  });
+</script>
+
+{#if $relatedSongs.length}
+  <CardGrid>
+    {#each $relatedSongs as song (song.id)}
+      <SongCard {song} />
+    {/each}
+  </CardGrid>
+{:else}
+  <p>Ingen relaterede sange fundet.</p>
+{/if}

--- a/src/lib/components/Song.svelte
+++ b/src/lib/components/Song.svelte
@@ -3,6 +3,7 @@
 	import Card from './Card.svelte';
 	import Like from './Like.svelte';
 	import AddToList from './AddToList.svelte';
+	import RelatedSongs from './RelatedSongs.svelte';
 
 	//Functions
 	import { encode } from '$functions/convertUrl';
@@ -44,4 +45,5 @@
 			</div>
 		</div>
 	</Card>
+	<RelatedSongs categoryId={song.categori_id} />
 {/if}

--- a/vite.config.js.timestamp-1730214293462-e644933a40bc9.mjs
+++ b/vite.config.js.timestamp-1730214293462-e644933a40bc9.mjs
@@ -1,0 +1,27 @@
+// vite.config.js
+import { sveltekit } from "file:///workspaces/spejderbogen/node_modules/@sveltejs/kit/src/exports/vite/index.js";
+import preprocess from "file:///workspaces/spejderbogen/node_modules/svelte-preprocess/dist/index.js";
+import path from "path";
+var config = {
+  plugins: [
+    sveltekit({
+      preprocess: [
+        preprocess({
+          postcss: true
+        })
+      ]
+    })
+  ],
+  resolve: {
+    alias: {
+      $components: path.resolve("./src/lib/components"),
+      $data: path.resolve("./src/lib/data"),
+      $functions: path.resolve("./src/lib/functions")
+    }
+  }
+};
+var vite_config_default = config;
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcuanMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvd29ya3NwYWNlcy9zcGVqZGVyYm9nZW5cIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfZmlsZW5hbWUgPSBcIi93b3Jrc3BhY2VzL3NwZWpkZXJib2dlbi92aXRlLmNvbmZpZy5qc1wiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9pbXBvcnRfbWV0YV91cmwgPSBcImZpbGU6Ly8vd29ya3NwYWNlcy9zcGVqZGVyYm9nZW4vdml0ZS5jb25maWcuanNcIjtpbXBvcnQgeyBzdmVsdGVraXQgfSBmcm9tICdAc3ZlbHRlanMva2l0L3ZpdGUnO1xuaW1wb3J0IHByZXByb2Nlc3MgZnJvbSAnc3ZlbHRlLXByZXByb2Nlc3MnO1xuaW1wb3J0IHBhdGggZnJvbSAncGF0aCc7XG5cbmNvbnN0IGNvbmZpZyA9IHtcbiAgICBwbHVnaW5zOiBbXG4gICAgICAgIHN2ZWx0ZWtpdCh7XG4gICAgICAgICAgICBwcmVwcm9jZXNzOiBbXG4gICAgICAgICAgICAgICAgcHJlcHJvY2Vzcyh7XG4gICAgICAgICAgICAgICAgICAgIHBvc3Rjc3M6IHRydWVcbiAgICAgICAgICAgICAgICB9KVxuICAgICAgICAgICAgXSxcbiAgICAgICAgfSlcbiAgICBdLFxuICAgIHJlc29sdmU6IHtcbiAgICAgICAgYWxpYXM6IHtcbiAgICAgICAgICAgICRjb21wb25lbnRzOiBwYXRoLnJlc29sdmUoJy4vc3JjL2xpYi9jb21wb25lbnRzJyksXG4gICAgICAgICAgICAkZGF0YTogcGF0aC5yZXNvbHZlKCcuL3NyYy9saWIvZGF0YScpLFxuICAgICAgICAgICAgJGZ1bmN0aW9uczogcGF0aC5yZXNvbHZlKCcuL3NyYy9saWIvZnVuY3Rpb25zJylcbiAgICAgICAgfVxuICAgIH1cbn07XG5cbmV4cG9ydCBkZWZhdWx0IGNvbmZpZzsiXSwKICAibWFwcGluZ3MiOiAiO0FBQTBQLFNBQVMsaUJBQWlCO0FBQ3BSLE9BQU8sZ0JBQWdCO0FBQ3ZCLE9BQU8sVUFBVTtBQUVqQixJQUFNLFNBQVM7QUFBQSxFQUNYLFNBQVM7QUFBQSxJQUNMLFVBQVU7QUFBQSxNQUNOLFlBQVk7QUFBQSxRQUNSLFdBQVc7QUFBQSxVQUNQLFNBQVM7QUFBQSxRQUNiLENBQUM7QUFBQSxNQUNMO0FBQUEsSUFDSixDQUFDO0FBQUEsRUFDTDtBQUFBLEVBQ0EsU0FBUztBQUFBLElBQ0wsT0FBTztBQUFBLE1BQ0gsYUFBYSxLQUFLLFFBQVEsc0JBQXNCO0FBQUEsTUFDaEQsT0FBTyxLQUFLLFFBQVEsZ0JBQWdCO0FBQUEsTUFDcEMsWUFBWSxLQUFLLFFBQVEscUJBQXFCO0FBQUEsSUFDbEQ7QUFBQSxFQUNKO0FBQ0o7QUFFQSxJQUFPLHNCQUFROyIsCiAgIm5hbWVzIjogW10KfQo=


### PR DESCRIPTION
Add RelatedSongs component to display related songs for the current song.

* **src/lib/components/Song.svelte**
  - Import RelatedSongs component.
  - Add RelatedSongs component below the current song's details.
  - Pass the current song's category ID as a prop to the RelatedSongs component.

* **src/lib/components/RelatedSongs.svelte**
  - Create a new Svelte component to display related songs.
  - Import CardGrid and SongCard components.
  - Fetch related songs based on the current song's category ID from the database.
  - Display related songs using the SongCard component.

* **vite.config.js.timestamp-1730214293462-e644933a40bc9.mjs**
  - Add alias for $components, $data, and $functions.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JacobArrow/spejderbogen?shareId=c92e40ad-f168-4cf5-9978-3e7a5a8999bf).